### PR TITLE
Add isort to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort
   - repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:


### PR DESCRIPTION
Adds isort to pre-commit to ensure imports stay formatted in accordance with PEP8