### PR TITLE
Add basic informational output to commands

### DIFF
--- a/reflex_cli/commands/command_build.py
+++ b/reflex_cli/commands/command_build.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 import click
-
 from reflex_cli.config_parser import ConfigParser
 from reflex_cli.template_generator import TemplateGenerator
 
@@ -36,4 +35,5 @@ def cli(config, output):
     configuration = ConfigParser(config)
     config_dictionary = configuration.generate_valid_config()
     generator = TemplateGenerator(config_dictionary, output)
+    LOGGER.info("Creating Terraform files...")
     generator.create_templates()

--- a/reflex_cli/commands/command_init.py
+++ b/reflex_cli/commands/command_init.py
@@ -2,7 +2,6 @@
 import logging
 
 import click
-
 from reflex_cli.cli import pass_environment
 from reflex_cli.reflex_initializer import ReflexInitializer
 
@@ -16,6 +15,7 @@ LOGGER = logging.getLogger("reflex_cli")
 def cli(context):
     """Creates a new reflex ready directory structure."""
     LOGGER.debug("Initializing reflex directory in: %s", context.home)
+    LOGGER.info("Generating reflex.yaml config file in: %s", context.home)
     initializer = ReflexInitializer(context.home)
     initializer.determine_config_values()
     initializer.write_config_file()

--- a/reflex_cli/commands/command_show.py
+++ b/reflex_cli/commands/command_show.py
@@ -3,6 +3,7 @@ Show command is used for discovery of detective measures that you may
 want to include in your reflex configuration.
 """
 import logging
+
 import click
 from reflex_cli.measure_discoverer import MeasureDiscoverer
 
@@ -13,5 +14,6 @@ LOGGER = logging.getLogger("reflex_cli")
 def cli():
     """CLI entrypoint for show command."""
     discoverer = MeasureDiscoverer()
+    LOGGER.info("Collecting list of available measures...")
     discoverer.collect_measures()
     discoverer.display_discovered_measures()


### PR DESCRIPTION
Provides very basic informational messages when running commands. Might want to add more later, but for now this should be sufficient.

Resolves #7 