### PR TITLE
Catch unhandled exception when config file format is invalid

### DIFF
--- a/reflex_cli/config_parser.py
+++ b/reflex_cli/config_parser.py
@@ -67,8 +67,12 @@ class ConfigParser:
     def parse_yaml_config(self):
         """Opens config file, parses yaml."""
         with open(self.config_file, "r") as config_file:
-            configuration = yaml.safe_load(config_file)
-            LOGGER.debug("Configuration dictionary: %s", configuration)
+            try:
+                configuration = yaml.safe_load(config_file)
+                LOGGER.debug("Configuration dictionary: %s", configuration)
+            except (yaml.scanner.ScannerError, yaml.parser.ParserError):
+                LOGGER.error("%s is not a valid yaml file.", self.config_file)
+                sys.exit(1)
         return configuration
 
     @staticmethod


### PR DESCRIPTION
Resolves #95 